### PR TITLE
Move to lib.deno.dev

### DIFF
--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,1 +1,1 @@
-export type { StorageAdapter } from "https://deno.land/x/grammy@v1.4.3/mod.ts";
+export type { StorageAdapter } from "https://lib.deno.dev/x/grammy@1.x/mod.ts";


### PR DESCRIPTION
This will change the module to use https://lib.deno.dev. As a result, the used dependency will automatically update to the newest version when a new version of grammY is released.