### PR TITLE
Removed Project ID property

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ import { DetaAdapter } from "https://deno.land/x/grammy_storage_deta/mod.ts";
 
 ## Introduction
 
-> Set up your Deta Base by creating a Deta project. Copy the Project ID and Project Key here.
+> Set up your Deta Base by creating a Deta project. Copy the Project Key to here.
 
 You should now have:
 
 1. A project key for your Deta.sh project.
-2. A project ID for Deta.sh project.
-3. A Telegram bot token.
+2. A Telegram bot token.
 
 Put those values into the following example code:
 
@@ -57,7 +56,6 @@ bot.use(session({
   storage: new DetaAdapter<SessionData>({
     baseName: "session", // <-- Base name - your choice.
     projectKey: "", // <-- Project Key here.
-    projectId: "", // <-- Project ID here.
   }),
 }));
 

--- a/examples/deno.ts
+++ b/examples/deno.ts
@@ -20,7 +20,6 @@ bot.use(session({
   storage: new DetaAdapter<SessionData>({
     baseName: "session", // <-- Base name - your choice.
     projectKey: "", // <-- Project Key here.
-    projectId: "", // <-- Project ID here.
   }),
 }));
 

--- a/examples/node.ts
+++ b/examples/node.ts
@@ -1,5 +1,4 @@
 // deno-lint-ignore-file
-
 import { Bot, Context, session, SessionFlavor } from "grammy";
 import { DetaAdapter } from "@grammyjs/storage-deta";
 
@@ -17,7 +16,6 @@ bot.use(session({
   storage: new DetaAdapter<SessionData>({
     baseName: "session", // <-- Base name - your choice.
     projectKey: "", // <-- Project Key here.
-    projectId: "", // <-- Project ID here.
   }),
 }));
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -3,7 +3,6 @@ import { StorageAdapter } from "./deps.deno.ts";
 export interface BaseConfig {
   baseName: string;
   projectKey: string;
-  projectId: string;
 }
 
 type Method = "GET" | "PUT" | "DELETE";
@@ -14,8 +13,9 @@ export class DetaAdapter<T> implements StorageAdapter<T> {
 
   constructor(project: BaseConfig) {
     this.project = project;
+    const projectId = project.projectKey.split("_")[0];
     this.rootUrl =
-      `https://database.deta.sh/v1/${project.projectId}/${project.baseName}/items`;
+      `https://database.deta.sh/v1/${projectId}/${project.baseName}/items`;
   }
 
   private async request(


### PR DESCRIPTION
Took me a while to realize that there is no need of a `projectId` property, since `projectId` is just the first part of the `projectKey`.
- Removed `projectId` property.
- Updated examples and README.